### PR TITLE
JTAND-10342 Drop node-saml/passport-saml version to 4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@devicefarmer/stf-wiki": "^1.0.0",
     "@dr.pogodin/csurf": "^1.14.1",
     "@julusian/jpeg-turbo": "^2.1.0",
-    "@node-saml/passport-saml": "^5.0.0",
+    "@node-saml/passport-saml": "^4.0.4",
     "@slack/web-api": "^7.7.0",
     "@targetprocess/swagger-tools": "^1.0.1",
     "android-device-list": "^1.2.10",


### PR DESCRIPTION
The Docker build passes and this downgrade may let us deploy and run the new STF with Android 15 support.